### PR TITLE
:recycle: Post entity, PostCreateDto 제약조건 추가

### DIFF
--- a/src/main/java/board/soyun_board/dto/PostCreateDto.java
+++ b/src/main/java/board/soyun_board/dto/PostCreateDto.java
@@ -1,18 +1,21 @@
 package board.soyun_board.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class PostCreateDto {
-    @NotBlank
+    @NotBlank(message = "제목을 입력하세요")
+    @Size(min = 1, max = 15, message = "제목은 최소 1자, 최대 15자까지 입력할 수 있습니다")
     private String title;
 
-    @NotBlank
+    @NotBlank(message = "내용을 입력하세요")
+    @Size(min = 1, max = 1000, message = "내용은 최소 1자, 최대 1000자까지 입력할 수 있습니다")
     private String content;
 
-    @NotBlank
+    @NotBlank(message = "글쓴이를 임력해주세요")
     private String author;
 }

--- a/src/main/java/board/soyun_board/entity/Post.java
+++ b/src/main/java/board/soyun_board/entity/Post.java
@@ -16,13 +16,13 @@ public class Post {
     @GeneratedValue
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private String title;
 
-    @Column
+    @Column(nullable = false)
     private String content;
 
-    @Column
+    @Column(nullable = false)
     private String author;
 
     @Builder


### PR DESCRIPTION
# 🚀 변경 사항
Post entity, PostCreateDto 제약조건 추가
- 게시글 `제목`, `내용`은 필수적으로 포함해야 한다.
- `제목`은 1글자 이상 15글자 이하여야 한다.
- `내용`은 1글자 이상 1000글자 이하여야 한다.
- `제목`은 공백으로만 이루어질 수는 없다.

## 📌 주요 변경 내역



## 🔗 관련 이슈



## 🔍 집중적으로 리뷰받고 싶은 부분



## 📋 테스트 내용



## 📚 참고 자료



### 📎 추가 사항


